### PR TITLE
Syntax fix in nomad.yaml

### DIFF
--- a/nomad.yaml
+++ b/nomad.yaml
@@ -6,7 +6,8 @@ plugins:
   # We only include our schema here. Without the explicit include, all plugins will be
   # loaded. Many build in plugins require more dependencies. Install nomad-lab[parsing]
   # to make all default plugins work.
-  include: 'schemas/example'
+  include:
+    - 'schemas/example'
   options:
     schemas/example:
       python_package: nomadschemaexample


### PR DESCRIPTION
This has been a source of confusion for the installation of plugins and following the documentation instruction in https://nomad-lab.eu/prod/v1/staging/docs/plugins/plugins.html#mount-into-a-nomad-oasis, in particular, the step "You simply have to add the plugin metadata to your Oasis' nomad.yaml`" was incorrect, because it seems that it needs to be a list, as per https://github.com/nomad-coe/nomad/issues/80#issuecomment-1678856053.

I don't know if this is the right approach but as list it should be help identifying the issue.